### PR TITLE
update Kyber OID

### DIFF
--- a/src/main/java/com/swiftcryptollc/crypto/provider/KyberJCE.java
+++ b/src/main/java/com/swiftcryptollc/crypto/provider/KyberJCE.java
@@ -21,7 +21,7 @@ import static sun.security.util.SecurityConstants.PROVIDER_VER;
 public final class KyberJCE extends Provider {
 
     private static final long serialVersionUID = 387564738298475632L;
-    public static final String OID_KYBER = "1.2.840.113549.1.3.1";
+    public static final String OID_KYBER = "1.3.6.1.4.1.2.267.8";
 
     private static final String info = "KyberJCE Provider "
             + "(implements CRYSTALS Kyber)";


### PR DESCRIPTION
- `1.2.840.113549.1.3.1` is already reserved for DH key agreement: 
   https://oid-rep.orange-labs.fr/get/1.2.840.113549.1.3.1
- the OID should be compatible across implementations, see e.g.  
   https://github.com/randombit/botan
- `1.3.6.1.4.1.2.267.8` is listed in the first IETF draft and an OID repo: 
   - https://datatracker.ietf.org/doc/html/draft-uni-qsckeys-00
   - https://oid-rep.orange-labs.fr/get/1.3.6.1.4.1.2.267.8