### PR TITLE
Reduced dependency on com.github.aelstad.keccakj library

### DIFF
--- a/src/main/java/com/swiftcryptollc/crypto/provider/Kyber1024KeyPairGenerator.java
+++ b/src/main/java/com/swiftcryptollc/crypto/provider/Kyber1024KeyPairGenerator.java
@@ -1,6 +1,5 @@
 package com.swiftcryptollc.crypto.provider;
 
-import com.github.aelstad.keccakj.fips202.SHA3_256;
 import com.swiftcryptollc.crypto.provider.kyber.Indcpa;
 import com.swiftcryptollc.crypto.provider.kyber.KyberParams;
 import com.swiftcryptollc.crypto.spec.KyberParameterSpec;
@@ -75,7 +74,7 @@ public final class Kyber1024KeyPairGenerator extends KeyPairGeneratorSpi {
             byte[] packedPrivateKey = indcpaPKI.getPackedPrivateKey();
             byte[] packedPublicKey = indcpaPKI.getPackedPublicKey();
             byte[] privateKeyFixedLength = new byte[KyberParams.Kyber1024SKBytes];
-            MessageDigest md = new SHA3_256();
+            MessageDigest md = MessageDigest.getInstance("SHA3-256");
 
             byte[] encodedHash = md.digest(packedPublicKey);
             byte[] pkh = new byte[encodedHash.length];

--- a/src/main/java/com/swiftcryptollc/crypto/provider/Kyber512KeyPairGenerator.java
+++ b/src/main/java/com/swiftcryptollc/crypto/provider/Kyber512KeyPairGenerator.java
@@ -1,6 +1,5 @@
 package com.swiftcryptollc.crypto.provider;
 
-import com.github.aelstad.keccakj.fips202.SHA3_256;
 import com.swiftcryptollc.crypto.provider.kyber.Indcpa;
 import com.swiftcryptollc.crypto.provider.kyber.KyberParams;
 import com.swiftcryptollc.crypto.spec.KyberParameterSpec;
@@ -75,7 +74,7 @@ public final class Kyber512KeyPairGenerator extends KeyPairGeneratorSpi {
             byte[] packedPublicKey = indcpaPKI.getPackedPublicKey();
             byte[] packedPrivateKey = indcpaPKI.getPackedPrivateKey();
             byte[] privateKeyFixedLength = new byte[KyberParams.Kyber512SKBytes];
-            MessageDigest md = new SHA3_256();
+            MessageDigest md = MessageDigest.getInstance("SHA3-256");
             byte[] encodedHash = md.digest(packedPublicKey);
             byte[] pkh = new byte[encodedHash.length];
             System.arraycopy(encodedHash, 0, pkh, 0, encodedHash.length);

--- a/src/main/java/com/swiftcryptollc/crypto/provider/Kyber768KeyPairGenerator.java
+++ b/src/main/java/com/swiftcryptollc/crypto/provider/Kyber768KeyPairGenerator.java
@@ -1,6 +1,5 @@
 package com.swiftcryptollc.crypto.provider;
 
-import com.github.aelstad.keccakj.fips202.SHA3_256;
 import com.swiftcryptollc.crypto.provider.kyber.Indcpa;
 import com.swiftcryptollc.crypto.provider.kyber.KyberParams;
 import com.swiftcryptollc.crypto.spec.KyberParameterSpec;
@@ -75,7 +74,7 @@ public final class Kyber768KeyPairGenerator extends KeyPairGeneratorSpi {
             byte[] packedPrivateKey = indcpaPKI.getPackedPrivateKey();
             byte[] packedPublicKey = indcpaPKI.getPackedPublicKey();
             byte[] privateKeyFixedLength = new byte[KyberParams.Kyber768SKBytes];
-            MessageDigest md = new SHA3_256();
+            MessageDigest md = MessageDigest.getInstance("SHA3-256");
 
             byte[] encodedHash = md.digest(packedPublicKey);
             byte[] pkh = new byte[encodedHash.length];

--- a/src/main/java/com/swiftcryptollc/crypto/provider/kyber/Indcpa.java
+++ b/src/main/java/com/swiftcryptollc/crypto/provider/kyber/Indcpa.java
@@ -1,7 +1,6 @@
 package com.swiftcryptollc.crypto.provider.kyber;
 
 import com.github.aelstad.keccakj.core.KeccakSponge;
-import com.github.aelstad.keccakj.fips202.SHA3_512;
 import com.github.aelstad.keccakj.fips202.Shake128;
 import com.github.aelstad.keccakj.fips202.Shake256;
 import com.swiftcryptollc.crypto.provider.KyberPackedPKI;
@@ -257,7 +256,7 @@ public final class Indcpa {
             byte[] publicSeed = new byte[KyberParams.paramsSymBytes];
             byte[] noiseSeed = new byte[KyberParams.paramsSymBytes];
 
-            MessageDigest h = new SHA3_512();
+            MessageDigest h = MessageDigest.getInstance("SHA3-512");
             SecureRandom sr = SecureRandom.getInstanceStrong();
             sr.nextBytes(publicSeed);
             byte[] fullSeed = h.digest(publicSeed);


### PR DESCRIPTION
Reasoning: Java has its own implementation of SHA3. However, they have decided not to implement SHAKEs, so I was unable to fully remove this dependency usage.

Addition:
I removed the try-catch for the encrypt functions in KybeyKeyAgreement.java. Instead of silently failing, the method should fail fast.

Tested on Amazon Corretto 17. All Unit Tests are green.